### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.6.2",
-    "isomorphic-fetch": "^3.0.0",
-    "md5": "^2.3.0",
     "tsx": "^3.13.0",
     "typescript": "^5.2.2"
   },
   "dependencies": {
     "dayjs": "^1.11.9",
+    "isomorphic-fetch": "^3.0.0",
+    "md5": "^2.3.0",
     "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
Move `md5` and `isomorphic-fetch` from `devDependencies` to `dependencies`.

Otherwise it throws these errors:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'isomorphic-fetch' imported from /node_modules/solis-cloud-api/dist/api.js
    at new NodeError (node:internal/errors:399:5)
    at packageResolve (node:internal/modules/esm/resolve:889:9)
    at moduleResolve (node:internal/modules/esm/resolve:938:20)
    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'md5' imported from /node_modules/solis-cloud-api/dist/authentication.js
    at new NodeError (node:internal/errors:399:5)
    at packageResolve (node:internal/modules/esm/resolve:889:9)
    at moduleResolve (node:internal/modules/esm/resolve:938:20)
    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40)
    at link (node:internal/modules/esm/module_job:76:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```